### PR TITLE
Add pydantic-settings dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ uvloop==0.19.0; sys_platform != 'win32'
 orjson==3.10.7
 sqlalchemy==2.0.32
 pytest==8.2.2
+pydantic-settings==2.*


### PR DESCRIPTION
## Summary
- add pydantic-settings to Python dependencies

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement pydantic-settings==2.*)
- `pytest` (fails: ImportError: cannot import name 'ContractName' from 'eth_typing')
- `python -m bot.main` (fails: PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package)

------
https://chatgpt.com/codex/tasks/task_e_689bee5df874832795b91d24d89c4321