### PR TITLE
refactor: replace validator with field_validator

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from pydantic import BaseSettings, Field, AnyUrl, validator
+from pydantic import Field, AnyUrl, field_validator
+from pydantic_settings import BaseSettings
 from typing import Literal
 
 
@@ -39,7 +40,7 @@ class Settings(BaseSettings):
         env_file = ".env"
         env_file_encoding = "utf-8"
 
-    @validator("MODE")
+    @field_validator("MODE", mode="before")
     def _lower_mode(cls, v: str) -> str:  # noqa: D401
         """Normalize mode to lowercase."""
         return v.lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 httpx==0.27.0
 tenacity==8.5.0
 pydantic==2.7.1
+pydantic-settings==2.2.1
 python-telegram-bot==21.4
 APScheduler==3.10.4
 pandas==2.2.2


### PR DESCRIPTION
## Summary
- replace deprecated Pydantic `validator` with `field_validator`
- add pydantic-settings dependency and import `BaseSettings` from it

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_689bee61453c832795ed453d85c30868