### PR TITLE
Provide defaults for Settings and dedupe requirements

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import Field, AnyUrl, field_validator
+from pydantic import AnyUrl, field_validator
 from typing import Literal
 
 
@@ -12,8 +12,8 @@ class Settings(BaseSettings):
 
     MODE: Literal["viewer", "active"] = "viewer"
     NETWORK: str = "arbitrum"
-    UNISWAP_SUBGRAPH_URL: AnyUrl
-    WALLET_ADDRESS: str
+    UNISWAP_SUBGRAPH_URL: AnyUrl = "https://example.com"
+    WALLET_ADDRESS: str = "0x0"
     PRIVATE_KEY: str | None = None
     HL_API_KEY: str | None = None
     HL_API_SECRET: str | None = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ uvloop==0.19.0; sys_platform != 'win32'
 orjson==3.10.7
 sqlalchemy==2.0.32
 pytest==8.2.2
-pydantic-settings==2.*


### PR DESCRIPTION
## Summary
- give `UNISWAP_SUBGRAPH_URL` and `WALLET_ADDRESS` default values and keep `field_validator`
- remove duplicate `pydantic-settings` entry in requirements

## Testing
- `pip install -r requirements.txt`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bf1d0ec188327bb4728848da7aaab