### PR TITLE
Ensure scheduled coroutines run

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -45,7 +45,12 @@ async def async_main() -> None:
     async with httpx.AsyncClient(timeout=10) as client:
         executor = Executor(client)
         scheduler = create_scheduler(settings.TZ)
-        schedule_main_loop(scheduler, lambda: main_loop(client, notifier, executor, oracle), interval=5)
+        schedule_main_loop(
+            scheduler,
+            main_loop,
+            args=(client, notifier, executor, oracle),
+            interval=5,
+        )
         schedule_reports(
             scheduler,
             lambda: notifier.send_report(build_daily_report()),


### PR DESCRIPTION
## Summary
- schedule jobs with `asyncio.create_task` so APScheduler runs coroutines
- pass main loop args directly to scheduler
- update report scheduling to avoid unawaited coroutine warnings

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf6933ee8832793b5e8566279c9ba