### PR TITLE
Ensure APScheduler awaits main loop job

### DIFF
--- a/bot/scheduler.py
+++ b/bot/scheduler.py
@@ -21,8 +21,8 @@ def schedule_main_loop(
 ) -> None:
     """Schedule main loop job."""
 
-    def job() -> asyncio.Task[Any]:
-        return asyncio.create_task(func(*args))
+    async def job() -> None:
+        await func(*args)
 
     scheduler.add_job(job, "interval", seconds=interval, id="main-loop", replace_existing=True)
 


### PR DESCRIPTION
## Summary
- Convert main loop job to an `async def` that awaits the target function
- Schedule the async job directly so APScheduler awaits it

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bf8858efc832797a6bd89c8a0c919