### PR TITLE
Wrap Uniswap subgraph URL in str

### DIFF
--- a/bot/data/uniswap.py
+++ b/bot/data/uniswap.py
@@ -25,7 +25,10 @@ query($owner: String!) {
 async def fetch_positions(client: httpx.AsyncClient, owner: str) -> List[Dict[str, Any]]:
     """Fetch positions from The Graph subgraph."""
     settings = get_settings()
-    resp = await client.post(settings.UNISWAP_SUBGRAPH_URL, json={"query": QUERY, "variables": {"owner": owner}})
+    resp = await client.post(
+        str(settings.UNISWAP_SUBGRAPH_URL),
+        json={"query": QUERY, "variables": {"owner": owner}},
+    )
     resp.raise_for_status()
     data = resp.json()["data"]["positions"]
     return data


### PR DESCRIPTION
## Summary
- Cast settings.UNISWAP_SUBGRAPH_URL to string when posting to the subgraph

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bfc1451788327bca782025d055d20