### PR TITLE
chore: add hyperliquid sdk dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ uvloop==0.19.0; sys_platform != 'win32'
 orjson==3.10.7
 sqlalchemy==2.0.32
 pytest==8.2.2
+hyperliquid-python-sdk


### PR DESCRIPTION
## Summary
- add `hyperliquid-python-sdk` to requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement hyperliquid-python-sdk)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0cae84e94832797caf1956f8bcc7f