### PR TITLE
Use Hyperliquid SDK for account state

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -38,7 +38,7 @@ async def main_loop(client: httpx.AsyncClient, notifier: Notifier, executor: Exe
             risk.exit_safe_mode(reason="uniswap_unavailable")
         lp_delta = delta
     try:
-        perp = await hyperliquid.fetch_positions(client, settings.WALLET_ADDRESS)
+        perp = await hyperliquid.fetch_positions(settings.WALLET_ADDRESS)
         perp_pos = float(perp.get("position", 0.0))
         margin = float(perp.get("margin", 0.0))
         funding_apr = float(perp.get("fundingApr", 0.0))

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ uvloop==0.19.0; sys_platform != 'win32'
 orjson==3.10.7
 sqlalchemy==2.0.32
 pytest==8.2.2
+hyperliquid-python-sdk


### PR DESCRIPTION
## Summary
- integrate Hyperliquid Python SDK for account and position queries
- drop hard-coded API URL in favor of SDK constants
- add SDK dependency

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0cae7d8708327967192c466ccf44d