### PR TITLE
Add Hyperliquid client with EIP-712 signing and mode handling

### DIFF
--- a/hyperliquid_client.py
+++ b/hyperliquid_client.py
@@ -1,0 +1,145 @@
+"""Hyperliquid HTTP client with EIP-712 signing support.
+
+This module provides minimal helpers to interact with the Hyperliquid REST API
+using a wallet address and private key for signing. Only the wallet address is
+required for public queries; the private key is only needed when submitting
+orders or cancellations.
+
+Environment variables used:
+- ``HL_WALLET_ADDRESS``: public address of the user wallet.
+- ``HL_PRIVATE_KEY``: private key used for signing (never logged).
+"""
+from __future__ import annotations
+
+import os
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+from eth_account import Account
+from eth_account.messages import encode_structured_data
+
+# Hyperliquid API endpoints
+API_BASE_URL = "https://api.hyperliquid.xyz"
+INFO_URL = f"{API_BASE_URL}/info"
+EXCHANGE_URL = f"{API_BASE_URL}/exchange"
+
+logger = logging.getLogger(__name__)
+
+
+def _get_wallet() -> str:
+    wallet = os.getenv("HL_WALLET_ADDRESS")
+    if not wallet:
+        raise RuntimeError("HL_WALLET_ADDRESS not set")
+    return wallet
+
+
+def _get_private_key() -> Optional[str]:
+    return os.getenv("HL_PRIVATE_KEY")
+
+
+def sign_eip712(data: Dict[str, Any], private_key: str) -> str:
+    """Sign an EIP-712 typed message and return the hex signature."""
+    signable = encode_structured_data(primitive=data)
+    signed = Account.sign_message(signable, private_key=private_key)
+    return signed.signature.hex()
+
+
+def get_hl_open_positions(wallet: str) -> Dict[str, Any]:
+    """Fetch open positions for ``wallet``.
+
+    This request does not require authentication.
+    """
+    payload = {"type": "userOpenPositions", "user": wallet}
+    resp = httpx.post(INFO_URL, json=payload, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _order_typed_data(order: Dict[str, Any]) -> Dict[str, Any]:
+    """Build EIP-712 typed data structure for order signing."""
+    return {
+        "types": {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+            ],
+            "Order": [
+                {"name": "symbol", "type": "string"},
+                {"name": "side", "type": "string"},
+                {"name": "size", "type": "uint256"},
+                {"name": "price", "type": "uint256"},
+                {"name": "reduceOnly", "type": "bool"},
+                {"name": "wallet", "type": "address"},
+            ],
+        },
+        "domain": {"name": "Hyperliquid", "version": "1", "chainId": 42161},
+        "primaryType": "Order",
+        "message": order,
+    }
+
+
+def _cancel_typed_data(cancel: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "types": {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+            ],
+            "Cancel": [
+                {"name": "orderId", "type": "string"},
+                {"name": "wallet", "type": "address"},
+            ],
+        },
+        "domain": {"name": "Hyperliquid", "version": "1", "chainId": 42161},
+        "primaryType": "Cancel",
+        "message": cancel,
+    }
+
+
+def place_order(symbol: str, side: str, size: float, price: Optional[float], reduce_only: bool = False) -> Dict[str, Any]:
+    """Submit a signed order to Hyperliquid.
+
+    If ``HL_PRIVATE_KEY`` is not defined the function logs and returns a
+    placeholder response without sending a request.
+    """
+    wallet = _get_wallet()
+    private_key = _get_private_key()
+    if not private_key:
+        logger.info("HL_PRIVATE_KEY not set – running in SAFE mode, order not sent")
+        return {"status": "safe_mode"}
+
+    order = {
+        "symbol": symbol,
+        "side": side,
+        "size": size,
+        "price": price or 0,
+        "reduceOnly": reduce_only,
+        "wallet": wallet,
+    }
+    typed = _order_typed_data(order)
+    signature = sign_eip712(typed, private_key)
+    body = {"order": order, "signature": signature, "wallet": wallet}
+    resp = httpx.post(EXCHANGE_URL, json=body, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def cancel_order(order_id: str) -> Dict[str, Any]:
+    """Cancel an existing order via signed request."""
+    wallet = _get_wallet()
+    private_key = _get_private_key()
+    if not private_key:
+        logger.info("HL_PRIVATE_KEY not set – running in SAFE mode, cancel not sent")
+        return {"status": "safe_mode"}
+
+    cancel = {"orderId": order_id, "wallet": wallet}
+    typed = _cancel_typed_data(cancel)
+    signature = sign_eip712(typed, private_key)
+    body = {"cancel": cancel, "signature": signature, "wallet": wallet}
+    resp = httpx.post(EXCHANGE_URL, json=body, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,59 @@
+"""Command-line entrypoint for Hyperliquid interactions.
+
+The script reads configuration from environment variables and only sends real
+orders when running in ``LIVE`` mode with ``HL_PRIVATE_KEY`` defined. In other
+modes it logs what would be executed.
+"""
+from __future__ import annotations
+
+import os
+import logging
+from typing import Optional
+
+from hyperliquid_client import get_hl_open_positions, place_order, cancel_order
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+MODE = os.getenv("MODE", "SAFE").upper()
+
+
+def safe_place_order(
+    symbol: str, side: str, size: float, price: Optional[float] = None, reduce_only: bool = False
+):
+    """Place an order respecting the current running mode."""
+    if MODE == "LIVE" and os.getenv("HL_PRIVATE_KEY"):
+        return place_order(symbol, side, size, price, reduce_only)
+    logger.info(
+        "executaria ordem %s %s size=%s price=%s, mas em modo %s",
+        side,
+        symbol,
+        size,
+        price,
+        MODE,
+    )
+    return {"status": "simulated"}
+
+
+def safe_cancel_order(order_id: str):
+    """Cancel an order respecting the running mode."""
+    if MODE == "LIVE" and os.getenv("HL_PRIVATE_KEY"):
+        return cancel_order(order_id)
+    logger.info("executaria cancelamento %s, mas em modo %s", order_id, MODE)
+    return {"status": "simulated"}
+
+
+def main() -> None:
+    wallet = os.getenv("HL_WALLET_ADDRESS")
+    if wallet:
+        positions = get_hl_open_positions(wallet)
+        logger.info("open positions: %s", positions)
+    else:
+        logger.info("HL_WALLET_ADDRESS not configured")
+
+    # Example placeholder
+    safe_place_order("ETH", "buy", 1.0, price=None)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ orjson==3.10.7
 sqlalchemy==2.0.32
 pytest==8.2.2
 hyperliquid-python-sdk
+eth-account==0.9.0


### PR DESCRIPTION
## Summary
- implement Hyperliquid REST client using wallet/private key signing
- expose order placement, cancellation and position query helpers
- ensure main entrypoint respects SAFE/PAPER/LIVE modes and simulate orders when not LIVE
- add eth-account dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install httpx python-dotenv` *(fails: Could not find a version that satisfies the requirement httpx; proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cd799c6c832781749bfa85c78444