### PR TITLE
feat: validate UNISWAP_SUBGRAPH_URL before running bot

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,8 @@
 #!/bin/bash
+
+if [ -z "$UNISWAP_SUBGRAPH_URL" ]; then
+  echo "Error: UNISWAP_SUBGRAPH_URL is not set. Please set it before running this script."
+  exit 1
+fi
+
 python -m bot.main


### PR DESCRIPTION
## Summary
- ensure run.sh exits when UNISWAP_SUBGRAPH_URL is unset

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement httpx==0.27.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68a0d4f5cda88327902ed32119c01771