### PR TITLE
Add helper to inject The Graph API key

### DIFF
--- a/tests/test_uniswap_fetch.py
+++ b/tests/test_uniswap_fetch.py
@@ -48,6 +48,14 @@ def test_fetch_positions_with_errors(monkeypatch):
     res = asyncio.run(run())
     assert res is None
 
+def test_with_thegraph_api_key_helper(monkeypatch):
+    base = "https://gateway.thegraph.com/api/subgraphs/id/XYZ"
+    monkeypatch.setenv("THEGRAPH_API_KEY", "ABC123")
+    assert (
+        uniswap._with_thegraph_api_key(base)
+        == "https://gateway.thegraph.com/api/ABC123/subgraphs/id/XYZ"
+    )
+
 
 def test_subgraph_url_includes_api_key(monkeypatch):
     base = "https://gateway.thegraph.com/api/subgraphs/id/XYZ"


### PR DESCRIPTION
## Summary
- add reusable `_with_thegraph_api_key` helper for The Graph URLs
- use helper in `_subgraph_url` and `graphql_query`
- add tests covering API key injection behavior

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement httpx==0.27.0 (403 Forbidden))*
- `pytest tests/test_uniswap_fetch.py::test_with_thegraph_api_key_helper -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a0d4ec98448327899db5a997eeced9