### PR TITLE
Handle optional Uniswap subgraph URL

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -12,7 +12,7 @@ class Settings(BaseSettings):
 
     MODE: Literal["viewer", "active"] = "viewer"
     NETWORK: str = "arbitrum"
-    UNISWAP_SUBGRAPH_URL: AnyUrl = "https://example.com"
+    UNISWAP_SUBGRAPH_URL: AnyUrl | None = None
     THEGRAPH_API_KEY: str | None = None
     WALLET_ADDRESS: str = "0x0"
     PRIVATE_KEY: str | None = None

--- a/bot/data/uniswap.py
+++ b/bot/data/uniswap.py
@@ -20,6 +20,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import httpx
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
+from ..config import get_settings
+
 
 logger = logging.getLogger(__name__)
 
@@ -117,10 +119,12 @@ def require_field(obj: Any, path: List[str]) -> tuple[Optional[Any], str]:
 def _subgraph_url() -> Optional[str]:
     """Return Uniswap subgraph URL with API key if available."""
 
-    url = os.getenv("UNISWAP_SUBGRAPH_URL")
+    settings = get_settings()
+    url = settings.UNISWAP_SUBGRAPH_URL
     if not url:
         return None
-    api_key = os.getenv("THEGRAPH_API_KEY")
+    url = str(url)
+    api_key = settings.THEGRAPH_API_KEY or os.getenv("THEGRAPH_API_KEY")
     if api_key and "/api/" in url and f"/{api_key}/" not in url:
         url = url.replace("/api/", f"/api/{api_key}/", 1)
     return url

--- a/tests/test_uniswap_fetch.py
+++ b/tests/test_uniswap_fetch.py
@@ -1,6 +1,7 @@
 import asyncio
 import httpx
 
+from bot.config import get_settings
 from bot.data import uniswap
 
 
@@ -10,6 +11,7 @@ def test_fetch_positions_handles_null(monkeypatch):
 
     transport = httpx.MockTransport(handler)
     monkeypatch.setenv("UNISWAP_SUBGRAPH_URL", "http://example.com")
+    get_settings.cache_clear()
 
     async def run():
         async with httpx.AsyncClient(transport=transport) as client:
@@ -25,6 +27,7 @@ def test_fetch_positions_empty(monkeypatch):
 
     transport = httpx.MockTransport(handler)
     monkeypatch.setenv("UNISWAP_SUBGRAPH_URL", "http://example.com")
+    get_settings.cache_clear()
 
     async def run():
         async with httpx.AsyncClient(transport=transport) as client:
@@ -40,6 +43,7 @@ def test_fetch_positions_with_errors(monkeypatch):
 
     transport = httpx.MockTransport(handler)
     monkeypatch.setenv("UNISWAP_SUBGRAPH_URL", "http://example.com")
+    get_settings.cache_clear()
 
     async def run():
         async with httpx.AsyncClient(transport=transport) as client:
@@ -53,6 +57,7 @@ def test_subgraph_url_includes_api_key(monkeypatch):
     base = "https://gateway.thegraph.com/api/subgraphs/id/XYZ"
     monkeypatch.setenv("UNISWAP_SUBGRAPH_URL", base)
     monkeypatch.setenv("THEGRAPH_API_KEY", "ABC123")
+    get_settings.cache_clear()
     assert (
         uniswap._subgraph_url()
         == "https://gateway.thegraph.com/api/ABC123/subgraphs/id/XYZ"


### PR DESCRIPTION
## Summary
- allow `UNISWAP_SUBGRAPH_URL` to be unset in config
- derive Uniswap subgraph URL from cached settings and inject API key
- clear cached settings in tests when modifying env vars

## Testing
- `pip install --disable-pip-version-check -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement httpx==0.27.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68a0d4eaf70c8327940490f4d5d71509